### PR TITLE
Specify Bazel target compatibility

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -25,7 +25,7 @@ jobs:
               env:
                   BAZELISK_GITHUB_TOKEN: ${{ secrets.BAZELISK_GITHUB_TOKEN }}
               run: |
-                  tools/bazelisk build //agents/... //observers/...
+                  tools/bazelisk build //...
 
     coverage:
         name: "Coverage"
@@ -43,7 +43,7 @@ jobs:
 
             - name: "Report test coverage"
               run: |
-                  tools/bazelisk coverage --combined_report=lcov --instrument_test_targets //agents/... //observers/...
+                  tools/bazelisk coverage --combined_report=lcov --instrument_test_targets //...
 
             - name: "Submit report to Coveralls"
               uses: coverallsapp/github-action@1.1.3
@@ -64,7 +64,7 @@ jobs:
               env:
                   BAZELISK_GITHUB_TOKEN: ${{ secrets.BAZELISK_GITHUB_TOKEN }}
               run: |
-                  tools/bazelisk test --config lint //agents/... //observers/...
+                  tools/bazelisk test --config lint //...
 
     test:
         name: "Test"
@@ -89,4 +89,4 @@ jobs:
               env:
                   BAZELISK_GITHUB_TOKEN: ${{ secrets.BAZELISK_GITHUB_TOKEN }}
               run: |
-                  tools/bazelisk test //agents/... //observers/...
+                  tools/bazelisk test //...

--- a/spines/BUILD
+++ b/spines/BUILD
@@ -77,6 +77,11 @@ cc_binary(
         "//:pi64_config": ["@vulp//actuation:pi3hat_interface"],
         "//conditions:default": [],
     }),
+    target_compatible_with = select({
+        "//:pi32_config": [],
+        "//:pi64_config": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
 )
 
 add_lint_tests(enable_clang_format_lint = True)

--- a/utils/spdlog.py
+++ b/utils/spdlog.py
@@ -64,7 +64,6 @@ logger.addHandler(handler)
 logging.basicConfig(level=logging.INFO)
 
 
-
 __all__ = [
     "logging",
 ]


### PR DESCRIPTION
Using ``target_compatible_with`` simplifies Bazel command lines and the CI.
